### PR TITLE
fix: No module named 'multipass' when using the connection plugin

### DIFF
--- a/plugins/connection/multipass.py
+++ b/plugins/connection/multipass.py
@@ -20,9 +20,6 @@ from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath
 
-from multipass import MultipassClient
-multipassclient = MultipassClient()
-
 display = Display()
 
 

--- a/tests/integration/targets/multipass_vm/tasks/main.yml
+++ b/tests/integration/targets/multipass_vm/tasks/main.yml
@@ -37,6 +37,10 @@
     that:
       - stop_vm.changed
 
+- name: Pause for 5 seconds to start the previously stopped VM
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Start a multipass VM which was stopped
   theko2fi.multipass.multipass_vm:
     name: "zazilapus"

--- a/tests/integration/targets/multipass_vm/tasks/main.yml
+++ b/tests/integration/targets/multipass_vm/tasks/main.yml
@@ -46,6 +46,9 @@
     name: "zazilapus"
     state: started
   register: start_vm
+  until: "start_vm is not failed"
+  retries: 3
+  delay: 10
 
 - name: Verify that VM has been started
   ansible.builtin.assert:


### PR DESCRIPTION
This PR comes in order to fix the issue mentioned here: #4 